### PR TITLE
Add support for AddAutoMapper via Microsoft.Extensions.DependencyInjection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = crlf
+
+[*.xml]
+indent_style = space
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/AutoMapper.Collection.EFCore.sln
+++ b/AutoMapper.Collection.EFCore.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{578F2483-CF08-409D-A316-31BCB7C5D9D0}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		README.md = README.md
 		version.props = version.props
 	EndProjectSection

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.1" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITests.cs
@@ -22,7 +22,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             services.AddAutoMapper(automapper =>
             {
                 automapper.AddCollectionMappers();
-                automapper.AddEntityFrameworkCoreKeys<DB>(services);
+                automapper.UseEntityFrameworkCoreModel<DB>(services);
             }, new Assembly[0]);
 
             this._serviceProvider = services.BuildServiceProvider();

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using AutoMapper.EntityFrameworkCore;
-using AutoMapper.EquivalencyExpression;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace AutoMapper.Collection.EntityFrameworkCore.Tests
@@ -15,46 +12,131 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
         protected abstract IMapper GetMapper();
 
         [Fact]
-        public void Should_Persist_To_Update()
+        public void Persist_InsertOrUpdate_WhenEntityExist_ThenTheEntityShouldBeInTheModifiedState()
         {
+            // Arrange
+            var mapper = GetMapper();
             var db = GetDbContext();
+
             db.Things.Add(new Thing { Title = "Test2" });
             db.Things.Add(new Thing { Title = "Test3" });
             db.Things.Add(new Thing { Title = "Test4" });
             db.SaveChanges();
-
-            Assert.Equal(3, db.Things.Count());
 
             var item = db.Things.First();
 
-            db.Things.Persist(GetMapper()).InsertOrUpdate(new ThingDto { ID = item.ID, Title = "Test" });
-            Assert.Equal(1, db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Modified));
+            // Act
+            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { ID = item.ID, Title = "Test" });
 
-            Assert.Equal(3, db.Things.Count());
-
-            db.Things.First(x => x.ID == item.ID).Title.Should().Be("Test");
+            // Assert
+            db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Modified).Should().Be(1);
         }
 
         [Fact]
-        public void Should_Persist_To_Insert()
+        public void Persist_InsertOrUpdate_WhenEntityExist_ThenTheEntityShouldBeUpdated()
         {
+            // Arrange
+            var mapper = GetMapper();
             var db = GetDbContext();
+
             db.Things.Add(new Thing { Title = "Test2" });
             db.Things.Add(new Thing { Title = "Test3" });
             db.Things.Add(new Thing { Title = "Test4" });
             db.SaveChanges();
 
-            Assert.Equal(3, db.Things.Count());
+            var item = db.Things.First();
 
-            db.Things.Persist(GetMapper()).InsertOrUpdate(new ThingDto { Title = "Test" });
-            Assert.Equal(3, db.Things.Count());
-            Assert.Equal(1, db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Added));
-
+            // Act
+            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { ID = item.ID, Title = "Test" });
             db.SaveChanges();
 
-            Assert.Equal(4, db.Things.Count());
+            // Assert
+            db.Things.Count().Should().Be(3);
+            db.Things.FirstOrDefault(x => x.ID == item.ID).Title.Should().Be("Test");
+        }
 
-            db.Things.OrderByDescending(x => x.ID).First().Title.Should().Be("Test");
+        [Fact]
+        public void Persist_InsertOrUpdate_WhenEntityDoesNotExist_ThenTheEntityShouldBeInTheAddedState()
+        {
+            // Arrange
+            var mapper = GetMapper();
+            var db = GetDbContext();
+
+            db.Things.Add(new Thing { Title = "Test2" });
+            db.Things.Add(new Thing { Title = "Test3" });
+            db.Things.Add(new Thing { Title = "Test4" });
+            db.SaveChanges();
+
+            // Act
+            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
+
+            // Assert
+            db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Added).Should().Be(1);
+        }
+
+        [Fact]
+        public void Persist_InsertOrUpdate_WhenEntityDoesNotExist_ThenTheEntityShouldBeInserted()
+        {
+            // Arrange
+            var mapper = GetMapper();
+            var db = GetDbContext();
+
+            db.Things.Add(new Thing { Title = "Test2" });
+            db.Things.Add(new Thing { Title = "Test3" });
+            db.Things.Add(new Thing { Title = "Test4" });
+            db.SaveChanges();
+
+            // Act
+            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
+            db.SaveChanges();
+
+            // Assert
+            db.Things.Count().Should().Be(4);
+            db.Things.OrderByDescending(x => x.ID).FirstOrDefault().Title.Should().Be("Test");
+        }
+
+        [Fact]
+        public void Persist_Remove_WhenEntityDoesNotExist_ThenTheEntityShouldBeInTheDeletedState()
+        {
+            // Arrange
+            var mapper = GetMapper();
+            var db = GetDbContext();
+
+            db.Things.Add(new Thing { Title = "Test2" });
+            db.Things.Add(new Thing { Title = "Test3" });
+            db.Things.Add(new Thing { Title = "Test4" });
+            db.SaveChanges();
+
+            var item = db.Things.First();
+
+            // Act
+            db.Things.Persist(mapper).Remove(new ThingDto { ID = item.ID, Title = "Test" });
+
+            // Assert
+            db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Deleted).Should().Be(1);
+        }
+
+        [Fact]
+        public void Persist_Remove_WhenEntityDoesNotExist_ThenTheEntityShouldBeDeleted()
+        {
+            // Arrange
+            var mapper = GetMapper();
+            var db = GetDbContext();
+
+            db.Things.Add(new Thing { Title = "Test2" });
+            db.Things.Add(new Thing { Title = "Test3" });
+            db.Things.Add(new Thing { Title = "Test4" });
+            db.SaveChanges();
+
+            var item = db.Things.First();
+
+            // Act
+            db.Things.Persist(mapper).Remove(new ThingDto { ID = item.ID, Title = "Test" });
+            db.SaveChanges();
+
+            // Assert
+            db.Things.Count().Should().Be(2);
+            db.Things.Find(item.ID).Should().BeNull();
         }
 
         public abstract class DBContextBase : DbContext

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
@@ -12,6 +12,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
     public abstract class EntityFramworkCoreTestsBase
     {
         protected abstract DBContextBase GetDbContext();
+        protected abstract IMapper GetMapper();
 
         [Fact]
         public void Should_Persist_To_Update()
@@ -26,7 +27,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 
             var item = db.Things.First();
 
-            db.Things.Persist().InsertOrUpdate(new ThingDto { ID = item.ID, Title = "Test" });
+            db.Things.Persist(GetMapper()).InsertOrUpdate(new ThingDto { ID = item.ID, Title = "Test" });
             Assert.Equal(1, db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Modified));
 
             Assert.Equal(3, db.Things.Count());
@@ -45,7 +46,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 
             Assert.Equal(3, db.Things.Count());
 
-            db.Things.Persist().InsertOrUpdate(new ThingDto { Title = "Test" });
+            db.Things.Persist(GetMapper()).InsertOrUpdate(new ThingDto { Title = "Test" });
             Assert.Equal(3, db.Things.Count());
             Assert.Equal(1, db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Added));
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Linq;
-using AutoMapper.EntityFrameworkCore;
 using AutoMapper.EquivalencyExpression;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Xunit;
 
 namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 {
@@ -17,7 +13,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             {
                 x.AddCollectionMappers();
                 x.CreateMap<ThingDto, Thing>().ReverseMap();
-                x.AddEntityFrameworkCoreKeys<DB>();
+                x.UseEntityFrameworkCoreModel<DB>();
             });
         }
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
@@ -17,13 +17,18 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             {
                 x.AddCollectionMappers();
                 x.CreateMap<ThingDto, Thing>().ReverseMap();
-                x.SetGeneratePropertyMaps<GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<DB>>();
+                x.AddEntityFrameworkCoreKeys<DB>();
             });
         }
 
         protected override DBContextBase GetDbContext()
         {
             return new DB();
+        }
+
+        protected override IMapper GetMapper()
+        {
+            return Mapper.Instance;
         }
 
         public class DB : DBContextBase

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingDITests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingDITests.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             {
                 x.ConstructServicesUsing(type => ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, type));
                 x.AddCollectionMappers();
-                x.AddEntityFrameworkCoreKeys<DB>(_serviceProvider);
+                x.UseEntityFrameworkCoreModel<DB>(_serviceProvider);
             });
 
             _serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope();

--- a/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
@@ -4,56 +4,26 @@ using System.Linq;
 using AutoMapper.EquivalencyExpression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace AutoMapper.EntityFrameworkCore
 {
-    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TDatabaseContext>
-        : IGeneratePropertyMaps
+    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TDatabaseContext> : IGeneratePropertyMaps
         where TDatabaseContext : DbContext
     {
-        private readonly IServiceProvider _serviceProvider;
+        private readonly IModel _model;
 
-        public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(IServiceProvider serviceProvider)
+        public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps()
         {
-            _serviceProvider = serviceProvider;
+            throw new InvalidOperationException("Use AddEntityFrameworkCoreKeys instead of using SetGeneratePropertyMaps.");
         }
 
-        public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps() { }
+        public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(IModel model) => _model = model;
 
         public IEnumerable<PropertyMap> GeneratePropertyMaps(TypeMap typeMap)
         {
-            using (var holder = new DbContextHolder(_serviceProvider))
-            {
-                var propertyMaps = typeMap.GetPropertyMaps();
-
-                var keyMembers = holder.DbContext.Model.FindEntityType(typeMap.DestinationType)?.FindPrimaryKey().Properties ?? new List<IProperty>();
-                return keyMembers.Select(m => Array.Find(propertyMaps, p => p.DestinationProperty.Name == m.Name));
-            }
-        }
-
-        private class DbContextHolder : IDisposable
-        {
-            private readonly IDisposable _disposable;
-
-            public DbContextHolder(IServiceProvider serviceProvider)
-            {
-                if (serviceProvider == null)
-                {
-                    DbContext = (DbContext)Activator.CreateInstance(typeof(TDatabaseContext));
-                    _disposable = DbContext;
-                }
-                else
-                {
-                    var scope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope();
-                    _disposable = scope;
-                    DbContext = ActivatorUtilities.GetServiceOrCreateInstance<TDatabaseContext>(scope.ServiceProvider);
-                }
-            }
-
-            public DbContext DbContext { get; }
-
-            public void Dispose() => _disposable.Dispose();
+            var propertyMaps = typeMap.GetPropertyMaps();
+            var keyMembers = _model.FindEntityType(typeMap.DestinationType)?.FindPrimaryKey().Properties ?? new List<IProperty>();
+            return keyMembers.Select(m => Array.Find(propertyMaps, p => p.DestinationProperty.Name == m.Name));
         }
     }
 }

--- a/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
@@ -13,12 +13,12 @@ namespace AutoMapper
         /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by creating an
         /// instance of the <see cref="DbContext"/> using the parameterless constructor.
         /// </summary>
-        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config)
+        public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config)
             where TContext : DbContext, new()
         {
             using (var context = new TContext())
             {
-                config.AddEntityFrameworkCoreKeys<TContext>(context.Model);
+                config.UseEntityFrameworkCoreModel<TContext>(context.Model);
             }
         }
 
@@ -27,12 +27,12 @@ namespace AutoMapper
         /// instance of the <see cref="DbContext"/> using a temporary <see cref="IServiceProvider"/> based on the <see cref="IServiceCollection"/>.
         /// This method is generally called from <see cref="IServiceCollection"/>.AddAutoMapper().
         /// </summary>
-        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceCollection services)
+        public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config, IServiceCollection services)
             where TContext : DbContext
         {
             using (var serviceProvider = services.BuildServiceProvider())
             {
-                config.AddEntityFrameworkCoreKeys<TContext>(serviceProvider);
+                config.UseEntityFrameworkCoreModel<TContext>(serviceProvider);
             }
         }
 
@@ -41,13 +41,13 @@ namespace AutoMapper
         /// instance of the <see cref="DbContext"/> using the <see cref="IServiceProvider"/>. This method is generally used when you are configuring
         /// AutoMapper using static initialization via <see cref="Mapper.Initialize(Action{IMapperConfigurationExpression})"/>.
         /// </summary>
-        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceProvider serviceProvider)
+        public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config, IServiceProvider serviceProvider)
             where TContext : DbContext
         {
             using (var scope = serviceProvider.CreateScope())
             using (var context = scope.ServiceProvider.GetRequiredService<TContext>())
             {
-                config.AddEntityFrameworkCoreKeys<TContext>(context.Model);
+                config.UseEntityFrameworkCoreModel<TContext>(context.Model);
             }
         }
 
@@ -55,7 +55,7 @@ namespace AutoMapper
         /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
         /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
         /// </summary>
-        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IModel model)
+        public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config, IModel model)
             where TContext : DbContext
         {
             config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TContext>(model));

--- a/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
@@ -45,8 +45,8 @@ namespace AutoMapper
             where TContext : DbContext
         {
             using (var scope = serviceProvider.CreateScope())
-            using (var context = scope.ServiceProvider.GetRequiredService<TContext>())
             {
+                var context = scope.ServiceProvider.GetRequiredService<TContext>();
                 config.UseEntityFrameworkCoreModel<TContext>(context.Model);
             }
         }

--- a/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using AutoMapper.EntityFrameworkCore;
+using AutoMapper.EquivalencyExpression;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AutoMapper
+{
+    public static class MapperConfigurationExpressionExtensions
+    {
+        /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by creating an
+        /// instance of the <see cref="DbContext"/> using the parameterless constructor.
+        /// </summary>
+        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config)
+            where TContext : DbContext, new()
+        {
+            using (var context = new TContext())
+            {
+                config.AddEntityFrameworkCoreKeys<TContext>(context.Model);
+            }
+        }
+
+        /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by resolving an
+        /// instance of the <see cref="DbContext"/> using a temporary <see cref="IServiceProvider"/> based on the <see cref="IServiceCollection"/>.
+        /// This method is generally called from <see cref="IServiceCollection"/>.AddAutoMapper().
+        /// </summary>
+        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceCollection services)
+            where TContext : DbContext
+        {
+            using (var serviceProvider = services.BuildServiceProvider())
+            {
+                config.AddEntityFrameworkCoreKeys<TContext>(serviceProvider);
+            }
+        }
+
+        /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by resolving an
+        /// instance of the <see cref="DbContext"/> using the <see cref="IServiceProvider"/>. This method is generally used when you are configuring
+        /// AutoMapper using static initialization via <see cref="Mapper.Initialize(Action{IMapperConfigurationExpression})"/>.
+        /// </summary>
+        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceProvider serviceProvider)
+            where TContext : DbContext
+        {
+            using (var scope = serviceProvider.CreateScope())
+            using (var context = scope.ServiceProvider.GetRequiredService<TContext>())
+            {
+                config.AddEntityFrameworkCoreKeys<TContext>(context.Model);
+            }
+        }
+
+        /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
+        /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
+        /// </summary>
+        public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IModel model)
+            where TContext : DbContext
+        {
+            config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TContext>(model));
+        }
+    }
+}


### PR DESCRIPTION
In response to https://github.com/AutoMapper/AutoMapper.Collection.EFCore/issues/2, to simplify the use of EFCore with AutoMapper, I added 4 extension methods to `IMapperConfigurationExpression` that users will use instead of `SetGeneratePropertyMaps`. I made sure to document the use case for each, including using the method via `Mapper.Initialize` as well as `IServiceCollection.AddAutoMapper`.

```csharp
public static class MapperConfigurationExpressionExtensions
{
    /// <summary>
    /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by creating an
    /// instance of the <see cref="DbContext"/> using the parameterless constructor.
    /// </summary>
    public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config)
    	where TContext : DbContext, new()

    /// <summary>
    /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by resolving an
    /// instance of the <see cref="DbContext"/> using a temporary <see cref="IServiceProvider"/> based on the <see cref="IServiceCollection"/>.
    /// This method is generally called from <see cref="IServiceCollection"/>.AddAutoMapper().
    /// </summary>
    public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceCollection services)
        where TContext : DbContext

    /// <summary>
    /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by resolving an
    /// instance of the <see cref="DbContext"/> using the <see cref="IServiceProvider"/>. This method is generally used when you are configuring
    /// AutoMapper using static initialization via <see cref="Mapper.Initialize(Action{IMapperConfigurationExpression})"/>.
    /// </summary>
    public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IServiceProvider serviceProvider)
        where TContext : DbContext

    /// <summary>
    /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
    /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
    /// </summary>
    public static void AddEntityFrameworkCoreKeys<TContext>(this IMapperConfigurationExpression config, IModel model)
        where TContext : DbContext
}
```