### PR TITLE
Added return value to IPersistence.InsertOrUpdate()

### DIFF
--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreTestsBase.cs
@@ -68,9 +68,10 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             db.SaveChanges();
 
             // Act
-            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
+            var createdThing = db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
 
             // Assert
+            Assert.NotNull(createdThing);
             db.ChangeTracker.Entries<Thing>().Count(x => x.State == EntityState.Added).Should().Be(1);
         }
 
@@ -87,12 +88,15 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
             db.SaveChanges();
 
             // Act
-            db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
+            var createdThing = db.Things.Persist(mapper).InsertOrUpdate(new ThingDto { Title = "Test" });
             db.SaveChanges();
 
             // Assert
+            Assert.NotNull(createdThing);
             db.Things.Count().Should().Be(4);
-            db.Things.OrderByDescending(x => x.ID).FirstOrDefault().Title.Should().Be("Test");
+            var createdThingFromEF = db.Things.OrderByDescending(x => x.ID).FirstOrDefault();
+            createdThingFromEF.Title.Should().Be("Test");
+            Assert.Equal(createdThing, createdThingFromEF);
         }
 
         [Fact]

--- a/src/AutoMapper.Collection.EntityFrameworkCore/Extensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/Extensions.cs
@@ -15,7 +15,7 @@ namespace AutoMapper.EntityFrameworkCore
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">DbSet to be updated</param>
         /// <returns>Persistence object to Update or Remove data</returns>
-        public static IPersistence Persist<TSource>(this DbSet<TSource> source)
+        public static IPersistence<TSource> Persist<TSource>(this DbSet<TSource> source)
             where TSource : class
         {
             return new Persistence<TSource>(source, Mapper.Instance);
@@ -28,7 +28,7 @@ namespace AutoMapper.EntityFrameworkCore
         /// <param name="source">DbSet to be updated</param>
         /// <param name="mapper">IMapper used to find TypeMap between classes</param>
         /// <returns>Persistence object to Update or Remove data</returns>
-        public static IPersistence Persist<TSource>(this DbSet<TSource> source, IMapper mapper)
+        public static IPersistence<TSource> Persist<TSource>(this DbSet<TSource> source, IMapper mapper)
             where TSource : class
         {
             return new Persistence<TSource>(source, mapper);

--- a/src/AutoMapper.Collection.EntityFrameworkCore/IPersistence.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/IPersistence.cs
@@ -2,7 +2,7 @@
 
 namespace AutoMapper.EntityFrameworkCore
 {
-    public interface IPersistence
+    public interface IPersistence<TTo>
     {
         /// <summary>
         /// Insert Or Update the <see cref="T:System.Data.Entity.DbSet`1"/> with <paramref name="from"/>
@@ -10,7 +10,7 @@ namespace AutoMapper.EntityFrameworkCore
         /// <remarks>Uses <see cref="AutoMapper.EquivalencyExpression.EquivalentExpressions.GenerateEquality"/>> to find equality between Source and From Types to determine if insert or update</remarks>
         /// <typeparam name="TFrom">Source Type mapping from</typeparam>
         /// <param name="from">Object to update to <see cref="T:System.Data.Entity.DbSet`1"/></param>
-        void InsertOrUpdate<TFrom>(TFrom from) where TFrom : class;
+        TTo InsertOrUpdate<TFrom>(TFrom from) where TFrom : class;
 
         /// <summary>
         /// Insert Or Update the <see cref="T:System.Data.Entity.DbSet`1"/> with <paramref name="from"/>
@@ -18,7 +18,7 @@ namespace AutoMapper.EntityFrameworkCore
         /// <remarks>Uses <see cref="AutoMapper.EquivalencyExpression.EquivalentExpressions.GenerateEquality"/>> to find equality between Source and From Types to determine if insert or update</remarks>
         /// <param name="type">Source Type mapping from</param>
         /// <param name="from">Object to update to <see cref="T:System.Data.Entity.DbSet`1"/></param>
-        void InsertOrUpdate(Type type, object from);
+        TTo InsertOrUpdate(Type type, object from);
 
         /// <summary>
         /// Remove from <see cref="T:System.Data.Entity.DbSet`1"/> with <paramref name="from"/>

--- a/src/AutoMapper.Collection.EntityFrameworkCore/Persistence.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/Persistence.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AutoMapper.EntityFrameworkCore
 {
-    public class Persistence<TTo> : IPersistence
+    public class Persistence<TTo> : IPersistence<TTo>
         where TTo : class
     {
         private readonly DbSet<TTo> _sourceSet;
@@ -17,19 +17,19 @@ namespace AutoMapper.EntityFrameworkCore
             _mapper = mapper;
         }
 
-        public void InsertOrUpdate<TFrom>(TFrom from)
+        public TTo InsertOrUpdate<TFrom>(TFrom from)
             where TFrom : class
         {
-            InsertOrUpdate(typeof(TFrom), from);
+            return InsertOrUpdate(typeof(TFrom), from);
         }
 
-        public void InsertOrUpdate(Type type, object from)
+        public TTo InsertOrUpdate(Type type, object from)
         {
             var equivExpr = _mapper == null
                 ? Mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>
                 : _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
             if (equivExpr == null)
-                return;
+                return null;
 
             var to = _sourceSet.FirstOrDefault(equivExpr);
 
@@ -45,6 +45,8 @@ namespace AutoMapper.EntityFrameworkCore
                 else
                     _mapper.Map(from, to);
             }
+
+            return to;
         }
 
         public void Remove<TFrom>(TFrom from)


### PR DESCRIPTION
I added a return value to the `DbSet<T>.Persist().InsertOrUpdate(dto)` to make it possible to retrieve the created entity when working with identity insert.