### PR TITLE
Update to AM.Collection 6 with AM 9

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageSources> 
+  <packageSources>
     <add key="AutoMapper" value="https://www.myget.org/F/automapperdev/api/v2" /> 
   </packageSources> 
 </configuration>

--- a/README.md
+++ b/README.md
@@ -7,29 +7,20 @@
 ## Configuration examples
 
 - Usage together with Dependency injection and AutoMapper.Extensions.Microsoft.DependencyInjection pacakge
-    ```	
-        var services = new ServiceCollection();
-        services
-            .AddEntityFrameworkInMemoryDatabase()
-            .AddDbContext<DB>();
+```	
+var services = new ServiceCollection();
+services
+    .AddEntityFrameworkInMemoryDatabase()
+    .AddDbContext<DB>();
 
-        services.AddAutoMapper((serviceProvider, automapper) =>
-        {
-            automapper.AddCollectionMappers();
-            automapper.UseEntityFrameworkCoreModel<DB>(serviceProvider);
-        }, typeof(DB).Assembly);
+services.AddAutoMapper((serviceProvider, automapper) =>
+{
+    automapper.AddCollectionMappers();
+    automapper.UseEntityFrameworkCoreModel<DB>(serviceProvider);
+}, typeof(DB).Assembly);
 
-        var serviceProvider = services.BuildServiceProvider();
-    ```
-
-	- Simple usage with static version of AutoMapper
-    ```
-        Mapper.Initialize(x =>
-        {
-            x.AddCollectionMappers();
-            x.UseEntityFrameworkCoreModel<DB>();
-        });
-    ```
+var serviceProvider = services.BuildServiceProvider();
+```
 
 **Note:** User defined equality expressions will overwrite primary key expressions.
 
@@ -39,10 +30,12 @@ Automapper.Collection.EntityFrameworkCore does that as well through extension me
 
 Translate equality between dto and EF object to an expression of just the EF using the dto's values as constants.
 
-	dbContext.Orders.Persist().InsertOrUpdate<OrderDTO>(newOrderDto);
-	dbContext.Orders.Persist().InsertOrUpdate<OrderDTO>(existingOrderDto);
-	dbContext.Orders.Persist().Remove<OrderDTO>(deletedOrderDto);
+```
+	dbContext.Orders.Persist(mapper).InsertOrUpdate<OrderDTO>(newOrderDto);
+	dbContext.Orders.Persist(mapper).InsertOrUpdate<OrderDTO>(existingOrderDto);
+	dbContext.Orders.Persist(mapper).Remove<OrderDTO>(deletedOrderDto);
 	dbContext.SubmitChanges();
+```
 
 **Note:** This is done by converting the OrderDTO to Expression<Func<Order,bool>> and using that to find matching type in the database.  You can also map objects to expressions as well.
 
@@ -51,6 +44,7 @@ Persist doesn't call submit changes automatically
 How to get it
 --------------------------------
 Use NuGet Package Manager to install the package or use any of the following command in NuGet Package Manager Console.
-	
-	PM> Install-Package AutoMapper.Collection.EntityFrameworkCore
 
+```	
+PM> Install-Package AutoMapper.Collection.EntityFrameworkCore
+```

--- a/build.ps1
+++ b/build.ps1
@@ -49,7 +49,7 @@ task compile -depends clean {
 	# restore all project references (creating project.assets.json for each project)
 	exec { dotnet restore $base_dir\AutoMapper.Collection.EFCore.sln /nologo }
 
-	exec { dotnet build $base_dir\AutoMapper.Collection.EFCore.sln -c $config $buildParam /nologo --no-restore }
+	exec { dotnet build $base_dir\AutoMapper.Collection.EFCore.sln -c $config $buildParam --no-restore /nologo }
 
 	exec { dotnet pack $base_dir\AutoMapper.Collection.EFCore.sln -c $config --include-symbols --no-build --no-restore --output $artifacts_dir $packageParam /nologo}
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.EntityFrameworkCore.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.1" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITests.cs
@@ -19,10 +19,11 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
                 .AddEntityFrameworkInMemoryDatabase()
                 .AddDbContext<DB>(options => options.UseInMemoryDatabase("EfTestDatabase" + Guid.NewGuid()));
 
-            services.AddAutoMapper(automapper =>
+            services.AddAutoMapper(x =>
             {
-                automapper.AddCollectionMappers();
-                automapper.UseEntityFrameworkCoreModel<DB>(services);
+                x.AddCollectionMappers();
+                x.UseEntityFrameworkCoreModel<DB>(services);
+                x.CreateMap<ThingDto, Thing>().ReverseMap();
             }, new Assembly[0]);
 
             this._serviceProvider = services.BuildServiceProvider();

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingCtorTests.cs
@@ -6,15 +6,16 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 {
     public class EntityFramworkCoreUsingCtorTests : EntityFramworkCoreTestsBase
     {
+        private readonly Mapper _mapper;
+
         public EntityFramworkCoreUsingCtorTests()
         {
-            Mapper.Reset();
-            Mapper.Initialize(x =>
+            _mapper = new Mapper(new MapperConfiguration(x =>
             {
                 x.AddCollectionMappers();
                 x.CreateMap<ThingDto, Thing>().ReverseMap();
                 x.UseEntityFrameworkCoreModel<DB>();
-            });
+            }));
         }
 
         protected override DBContextBase GetDbContext()
@@ -24,7 +25,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 
         protected override IMapper GetMapper()
         {
-            return Mapper.Instance;
+            return _mapper;
         }
 
         public class DB : DBContextBase

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingDITests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFramworkCoreUsingDITests.cs
@@ -9,6 +9,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
     public class EntityFramworkCoreUsingDITests : EntityFramworkCoreTestsBase, IDisposable
     {
         private readonly ServiceProvider _serviceProvider;
+        private readonly Mapper _mapper;
         private readonly IServiceScope _serviceScope;
 
         public EntityFramworkCoreUsingDITests()
@@ -21,13 +22,13 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 
             _serviceProvider = services.BuildServiceProvider();
 
-            Mapper.Reset();
-            Mapper.Initialize(x =>
+            _mapper = new Mapper(new MapperConfiguration(x =>
             {
                 x.ConstructServicesUsing(type => ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, type));
                 x.AddCollectionMappers();
                 x.UseEntityFrameworkCoreModel<DB>(_serviceProvider);
-            });
+                x.CreateMap<ThingDto, Thing>().ReverseMap();
+            }));
 
             _serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope();
         }
@@ -45,7 +46,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 
         protected override IMapper GetMapper()
         {
-            return Mapper.Instance;
+            return _mapper;
         }
 
         public class DB : DBContextBase

--- a/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="6.0.0-alpha-1908131117" />
+    <PackageReference Include="AutoMapper.Collection" Version="6.0.0-ci-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="5.0.0" />
+    <PackageReference Include="AutoMapper.Collection" Version="6.0.0-alpha-1908131117" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection.EntityFrameworkCore/Extensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/Extensions.cs
@@ -9,16 +9,18 @@ namespace AutoMapper.EntityFrameworkCore
     public static class Extensions
     {
         /// <summary>
+        /// Obsolete: Use Persist(IMapper) instead.
         /// Create a Persistence object for the <see cref="T:System.Data.Entity.DbSet`1"/> to have data persisted or removed from
         /// Uses static API's Mapper for finding TypeMap between classes
         /// </summary>
         /// <typeparam name="TSource">Source table type to be updated</typeparam>
         /// <param name="source">DbSet to be updated</param>
         /// <returns>Persistence object to Update or Remove data</returns>
+        [Obsolete("Use Persist(IMapper) instead.", true)]
         public static IPersistence<TSource> Persist<TSource>(this DbSet<TSource> source)
             where TSource : class
         {
-            return new Persistence<TSource>(source, Mapper.Instance);
+            throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/AutoMapper.Collection.EntityFrameworkCore/Persistence.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/Persistence.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.EntityFrameworkCore
         public Persistence(DbSet<TTo> sourceSet, IMapper mapper)
         {
             _sourceSet = sourceSet;
-            _mapper = mapper;
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         }
 
         public TTo InsertOrUpdate<TFrom>(TFrom from)
@@ -85,15 +85,12 @@ namespace AutoMapper.EntityFrameworkCore
         {
             if (to == null)
             {
-                to = (TTo)(_mapper?.Map(from, type, typeof(TTo)) ?? Mapper.Map(from, type, typeof(TTo)));
+                to = (TTo)_mapper.Map(from, type, typeof(TTo));
                 _sourceSet.Add(to);
             }
             else
             {
-                if (_mapper == null)
-                    Mapper.Map(from, to);
-                else
-                    _mapper.Map(from, to);
+                _mapper.Map(from, to);
             }
             return to;
         }
@@ -105,9 +102,7 @@ namespace AutoMapper.EntityFrameworkCore
 
         private Expression<Func<TTo, bool>> GetEquivalenceExpression(Type type, object from)
         {
-            return _mapper == null
-                ? Mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>
-                : _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
+            return _mapper.Map(from, type, typeof(Expression<Func<TTo, bool>>)) as Expression<Func<TTo, bool>>;
         }
     }
 }

--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update to use AM.Collection 6 and AM 9.

To be able to get the build to pass we need a new version of AM.Collection out first, the `AutoMapper.Collection.EntityFrameworkCore.csproj` pointing to a ci-version of AM.Collection from myget feed.