### PR TITLE
Use UseEntityFrameworkCoreModel instead of AddEntityFrameworkCoreKeys in error message and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AutoMapper.Collection.EFCore
     Mapper.Initialize(cfg =>
     {
         cfg.AddCollectionMappers();
-        cfg.SetGeneratePropertyMaps<GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<DB>>();
+        cfg.UseEntityFrameworkCoreModel<DB>(serviceProvider);
         // Configuration code
     });
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
@@ -14,7 +14,7 @@ namespace AutoMapper.EntityFrameworkCore
 
         public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps()
         {
-            throw new InvalidOperationException("Use AddEntityFrameworkCoreKeys instead of using SetGeneratePropertyMaps.");
+            throw new InvalidOperationException("Use UseEntityFrameworkCoreModel instead of using SetGeneratePropertyMaps.");
         }
 
         public GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(IModel model) => _model = model;


### PR DESCRIPTION
I just ran into this small (non-)issue where during the review process #3 the method name changed from the initial `AddEntityFrameworkCoreKeys` to `UseEntityFrameworkCoreModel `. 

This change however was not reflected in the error message that is thrown when using the deprecated `SetGeneratePropertyMaps` nor in the README. 