### PR TITLE
Made some non generic versions of UseEntityFrameworkCoreModel

### DIFF
--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingDITestsNonGeneric.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingDITestsNonGeneric.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using AutoMapper.EquivalencyExpression;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AutoMapper.Collection.EntityFrameworkCore.Tests
+{
+    public class EntityFrameworkCoreUsingDITestsNonGeneric : EntityFramworkCoreTestsBase
+    {
+        private readonly ServiceProvider _serviceProvider;
+        private readonly IServiceScope _serviceScope;
+
+        public EntityFrameworkCoreUsingDITestsNonGeneric()
+        {
+            var services = new ServiceCollection();
+
+            services
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<DB>(options => options.UseInMemoryDatabase("EfTestDatabase" + Guid.NewGuid()));
+
+            _serviceProvider = services.BuildServiceProvider();
+
+            mapper = new Mapper(new MapperConfiguration(x =>
+            {
+                x.ConstructServicesUsing(type => ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, type));
+                x.AddCollectionMappers();
+                var contextType = typeof(DB);
+                x.UseEntityFrameworkCoreModel(contextType, _serviceProvider);
+                x.CreateMap<ThingDto, Thing>().ReverseMap();
+            }));
+
+            _serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            db = _serviceScope.ServiceProvider.GetRequiredService<DB>();
+        }
+
+        public override void Dispose()
+        {
+            _serviceScope?.Dispose();
+            _serviceProvider?.Dispose();
+            base.Dispose();
+        }
+
+        public class DB : DBContextBase
+        {
+            public DB(DbContextOptions dbContextOptions)
+                : base(dbContextOptions)
+            {
+            }
+        }
+    }
+}

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITestsNonGeneric.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingMicrosoftDITestsNonGeneric.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Reflection;
+using AutoMapper.EquivalencyExpression;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AutoMapper.Collection.EntityFrameworkCore.Tests
+{
+    public class EntityFrameworkCoreUsingMicrosoftDITestsNonGeneric : EntityFramworkCoreTestsBase
+    {
+        private readonly ServiceProvider _serviceProvider;
+        private readonly IServiceScope _serviceScope;
+
+        public EntityFrameworkCoreUsingMicrosoftDITestsNonGeneric()
+        {
+            var services = new ServiceCollection();
+
+            services
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<DB>(options => options.UseInMemoryDatabase("EfTestDatabase" + Guid.NewGuid()));
+
+            services.AddAutoMapper(x =>
+            {
+                x.AddCollectionMappers();
+                var contextType = typeof(DB);
+                x.UseEntityFrameworkCoreModel(contextType, services);
+                x.CreateMap<ThingDto, Thing>().ReverseMap();
+            }, new Assembly[0]);
+
+            _serviceProvider = services.BuildServiceProvider();
+            _serviceScope = _serviceProvider.CreateScope();
+
+            mapper = _serviceScope.ServiceProvider.GetRequiredService<IMapper>();
+            db = _serviceScope.ServiceProvider.GetRequiredService<DB>();
+        }
+
+        public override void Dispose()
+        {
+            _serviceScope?.Dispose();
+            _serviceProvider?.Dispose();
+            base.Dispose();
+        }
+
+
+        public class DB : DBContextBase
+        {
+            public DB(DbContextOptions dbContextOptions)
+                : base(dbContextOptions)
+            {
+            }
+        }
+    }
+}

--- a/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
@@ -12,6 +12,8 @@
     <AssemblyOriginatorKeyFile>../Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
@@ -7,8 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace AutoMapper.EntityFrameworkCore
 {
-    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TDatabaseContext> : IGeneratePropertyMaps
-        where TDatabaseContext : DbContext
+    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps : IGeneratePropertyMaps
     {
         private readonly IModel _model;
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
@@ -37,6 +37,19 @@ namespace AutoMapper
         }
 
         /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="Type"/>. This is done by resolving an
+        /// instance of the <see cref="Type"/> to a <see cref="DbContext"/> using a temporary <see cref="IServiceProvider"/> based on the <see cref="IServiceCollection"/>.
+        /// This method is generally called from <see cref="IServiceCollection"/>.AddAutoMapper().
+        /// </summary>
+        public static void UseEntityFrameworkCoreModel(this IMapperConfigurationExpression config, Type contextType, IServiceCollection services)
+        {
+            using (var serviceProvider = services.BuildServiceProvider())
+            {
+                config.UseEntityFrameworkCoreModel(contextType, serviceProvider);
+            }
+        }
+
+        /// <summary>
         /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This is done by resolving an
         /// instance of the <see cref="DbContext"/> using the <see cref="IServiceProvider"/>. This method is generally used when you are configuring
         /// AutoMapper using static initialization via <see cref="Mapper.Initialize(Action{IMapperConfigurationExpression})"/>.
@@ -52,10 +65,30 @@ namespace AutoMapper
         }
 
         /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="Type"/>. This is done by resolving an
+        /// instance of the <see cref="Type"/> to a <see cref="DbContext"/> using the <see cref="IServiceProvider"/>. This method is generally used when you are configuring
+        /// AutoMapper using static initialization via <see cref="Mapper.Initialize(Action{IMapperConfigurationExpression})"/>.
+        /// </summary>
+        public static void UseEntityFrameworkCoreModel(this IMapperConfigurationExpression config, Type contextType, IServiceProvider serviceProvider)
+        {
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = (DbContext)scope.ServiceProvider.GetRequiredService(contextType);
+                config.UseEntityFrameworkCoreModel(context.Model);
+            }
+        }
+
+        /// <summary>
         /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
         /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
         /// </summary>
         public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config, IModel model)
-            where TContext : DbContext => config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TContext>(model));
+            where TContext : DbContext => config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(model));
+
+        /// <summary>
+        /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
+        /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
+        /// </summary>
+        public static void UseEntityFrameworkCoreModel(this IMapperConfigurationExpression config, IModel model) => config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(model));
     }
 }


### PR DESCRIPTION
we have a need to register more than one context per solution, and our registration code is in a different library, so we would like to pass a Type to the method to register it (like the RegisterScoped method calls etc)