### PR TITLE
Fixes #57

### DIFF
--- a/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs
@@ -7,8 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace AutoMapper.EntityFrameworkCore
 {
-    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TDatabaseContext> : IGeneratePropertyMaps
-        where TDatabaseContext : DbContext
+    public class GenerateEntityFrameworkCorePrimaryKeyPropertyMaps : IGeneratePropertyMaps
     {
         private readonly IModel _model;
 
@@ -20,7 +19,7 @@ namespace AutoMapper.EntityFrameworkCore
         {
             var propertyMaps = typeMap.PropertyMaps;
             var keyMembers = _model.FindEntityType(typeMap.DestinationType)?.FindPrimaryKey().Properties ?? new List<IProperty>();
-            return keyMembers.Select(m => propertyMaps.FirstOrDefault(p => p.DestinationMember.Name == m.Name));
+            return propertyMaps.Where(p => keyMembers.Any(m => m.Name == p.DestinationMember.Name));
         }
     }
 }

--- a/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/MapperConfigurationExpressionExtensions.cs
@@ -18,7 +18,7 @@ namespace AutoMapper
         {
             using (var context = new TContext())
             {
-                config.UseEntityFrameworkCoreModel<TContext>(context.Model);
+                config.UseEntityFrameworkCoreModel(context.Model);
             }
         }
 
@@ -47,7 +47,7 @@ namespace AutoMapper
             using (var scope = serviceProvider.CreateScope())
             {
                 var context = scope.ServiceProvider.GetRequiredService<TContext>();
-                config.UseEntityFrameworkCoreModel<TContext>(context.Model);
+                config.UseEntityFrameworkCoreModel(context.Model);
             }
         }
 
@@ -55,7 +55,7 @@ namespace AutoMapper
         /// Generates and adds property maps based on the primary keys for the given <see cref="DbContext"/>. This method is generally
         /// only used if you are using <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>.
         /// </summary>
-        public static void UseEntityFrameworkCoreModel<TContext>(this IMapperConfigurationExpression config, IModel model)
-            where TContext : DbContext => config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps<TContext>(model));
+        public static void UseEntityFrameworkCoreModel(this IMapperConfigurationExpression config, IModel model)
+            => config.SetGeneratePropertyMaps(new GenerateEntityFrameworkCorePrimaryKeyPropertyMaps(model));
     }
 }


### PR DESCRIPTION
If the primary key doesn't exist on the DTO, we can receive an `Object reference not set to an instance of an object` exception because the [GeneratePropertyMaps](https://github.com/AutoMapper/AutoMapper.Collection.EFCore/blob/d8c6ef84cf8501e3cb390a66df94717f8d759060/src/AutoMapper.Collection.EntityFrameworkCore/GenerateEntityFrameworkCorePrimaryKeyPropertyMaps.cs#L19) method can return a collection with a null value due to the `.FirstOrDefault`.

This PR also removes the unecessary `<TDatabaseContext>` type on `GenerateEntityFrameworkCorePrimaryKeyPropertyMaps` class.
