### PR TITLE
Updates target frameworks and dependencies

### DIFF
--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/AutoMapper.Collection.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.EntityFrameworkCore.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="AutoMapper" Version="[15.0.1, 16.0.0)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingCtorTests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingCtorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AutoMapper.EquivalencyExpression;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 {
@@ -13,7 +14,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
                 x.AddCollectionMappers();
                 x.CreateMap<ThingDto, Thing>().ReverseMap();
                 x.UseEntityFrameworkCoreModel<DB>();
-            }));
+            }, new NullLoggerFactory()));
 
             db = new DB();
         }

--- a/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingDITests.cs
+++ b/src/AutoMapper.Collection.EntityFrameworkCore.Tests/EntityFrameworkCoreUsingDITests.cs
@@ -2,6 +2,7 @@
 using AutoMapper.EquivalencyExpression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AutoMapper.Collection.EntityFrameworkCore.Tests
 {
@@ -26,7 +27,7 @@ namespace AutoMapper.Collection.EntityFrameworkCore.Tests
                 x.AddCollectionMappers();
                 x.UseEntityFrameworkCoreModel<DB>(_serviceProvider);
                 x.CreateMap<ThingDto, Thing>().ReverseMap();
-            }));
+            }, new NullLoggerFactory()));
 
             _serviceScope = _serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope();
             db = _serviceScope.ServiceProvider.GetRequiredService<DB>();

--- a/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
+++ b/src/AutoMapper.Collection.EntityFrameworkCore/AutoMapper.Collection.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Collection updating support for EntityFrameworkCore with AutoMapper. Extends DBSet&lt;T&gt; with Persist&lt;TDto&gt;().InsertUpdate(dto) and Persist&lt;TDto&gt;().Delete(dto).  Will find the matching object and will Insert/Update/Delete.</Description>
     <Authors>Tyler Carlson</Authors>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AssemblyName>AutoMapper.Collection.EntityFrameworkCore</AssemblyName>
     <PackageId>AutoMapper.Collection.EntityFrameworkCore</PackageId>
     <PackageIcon>icon.png</PackageIcon>
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Collection" Version="[11.0.0,12.0.0)" />
-    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[8.0.0,9.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageReference Include="AutoMapper.Collection" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates target frameworks to include net9.0.

Updates dependency versions for:
- AutoMapper
- AutoMapper.Collection
- AutoMapper.Extensions.ExpressionMapping
- Microsoft.EntityFrameworkCore

Adds NullLoggerFactory to fix constructor injection with newer AutoMapper versions.